### PR TITLE
target netstandard2.1 for better code sharing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 obj/
 bin/
 .vs/
+*.idea*

--- a/KzBsv/Keys/KzMnemonic.cs
+++ b/KzBsv/Keys/KzMnemonic.cs
@@ -5,10 +5,8 @@
 using System;
 using System.Buffers;
 using System.Collections.Generic;
-using System.Globalization;
 using System.Linq;
 using System.Numerics;
-using System.Security.Cryptography;
 using System.Text;
 
 namespace KzBsv {
@@ -388,7 +386,6 @@ namespace KzBsv {
         /// CAUTION: Will pad array with zero bytes if number is small.
         /// </summary>
         /// <param name="big"></param>
-        /// <param name="length"></param>
         /// <returns></returns>
         static string BigIntegerToBase6(BigInteger big)
         {
@@ -451,7 +448,7 @@ namespace KzBsv {
         /// <returns>Returns the entropy as a byte[] from a string of base 6 digits.</returns>
         static byte[] Base6ToEntropy(string base6, int length = 128)
         {
-            var needDigits = (int)Math.Ceiling(length / Math.Log2(6));
+            var needDigits = (int)Math.Ceiling(length / Math.Log(6, 2));
             if (base6.Length < needDigits)
                 throw new ArgumentException($"For {length} bits of entropy, at least {needDigits} digits of base 6 are needed.");
             return BigIntegerToEntropy(Base6ToBigInteger(base6), length);
@@ -468,7 +465,7 @@ namespace KzBsv {
         /// <returns>Returns the entropy as a byte[] from a string of base 10 digits.</returns>
         static byte[] Base10ToEntropy(string base10, int length = 128)
         {
-            var needDigits = (int)Math.Ceiling(length / Math.Log2(10));
+            var needDigits = (int)Math.Ceiling(length / Math.Log(10, 2));
             if (base10.Length < needDigits)
                 throw new ArgumentException($"For {length} bits of entropy, at least {needDigits} digits of base 10 are needed.");
             return BigIntegerToEntropy(Base10ToBigInteger(base10), length);

--- a/KzBsv/KzBsv.csproj
+++ b/KzBsv/KzBsv.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <RootNamespace>KzBsv</RootNamespace>
     <LangVersion>8.0</LangVersion>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
@@ -28,12 +28,14 @@
   <ItemGroup>
     <PackageReference Include="DnsClient" Version="1.2.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
+    <PackageReference Include="KzSecp256k1.Net" Version="0.1.0" />
+    <PackageReference Include="Secp256k1.Native" Version="0.1.20" />
   </ItemGroup>
 
   <ItemGroup>
     <None Include="..\LICENSE">
       <Pack>True</Pack>
-      <PackagePath></PackagePath>
+      <PackagePath>\</PackagePath>
     </None>
   </ItemGroup>
 

--- a/bricks/KzSecp256k1.Net/KzSecp256k1.Net.csproj
+++ b/bricks/KzSecp256k1.Net/KzSecp256k1.Net.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <LangVersion>latest</LangVersion>
@@ -37,8 +37,8 @@
       <_PackageFiles Include="$(OutputPath)/native/**/*">
         <BuildAction>Content</BuildAction>
         <PackagePath>content/native/</PackagePath>
-        <!--<CopyToOutput>true</CopyToOutput>-->
-        <!--<PackageCopyToOutput>true</PackageCopyToOutput>-->
+        <CopyToOutput>true</CopyToOutput>
+        <PackageCopyToOutput>true</PackageCopyToOutput>
       </_PackageFiles>
     </ItemGroup>
   </Target>

--- a/tests/Tests.KzBsv/Tests.KzBsv.csproj
+++ b/tests/Tests.KzBsv/Tests.KzBsv.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
 
@@ -29,7 +29,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.1" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/tests/Tests.KzSecp256k1.Net/Tests.KzSecp256k1.Net.csproj
+++ b/tests/Tests.KzSecp256k1.Net/Tests.KzSecp256k1.Net.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <IsPackable>false</IsPackable>
     <LangVersion>7.2</LangVersion>
     <RootNamespace>Secp256k1Net.Test</RootNamespace>
@@ -15,7 +15,7 @@
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
see: https://docs.microsoft.com/en-us/dotnet/standard/net-standard
- "Use netstandard2.1 to share code between Mono, Xamarin, and .NET Core 3.x."

- Add required package references for main KzBsv.csproj so that downstream consumers will pull in the required secp256k1 native binaries - currently the native binaries stay sitting in the KzSecp256k1.Net NuGet package directory and do not get copied to the output build dir).

Reason I prefer netstandard2.1 is because I want to potentially dabble with a bit of cross-platform experimentation.

And this library is already netstandard2.1 compliant anyway so seems pointless to cut off a wider potential user base. 


edit: Hmmm I'm not sure about this hack to include KzSecp256k1.Net native binaries... It may not always work...

